### PR TITLE
Support GitHub actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,7 @@ Currently detects:
 * Bamboo
 * CircleCI
 * CodeShip
+* GitHub Actions
 * GitlabCI
 * Hudson
 * Jenkins

--- a/pytest_vw.py
+++ b/pytest_vw.py
@@ -11,17 +11,18 @@ import pytest
 
 
 EXAMINATORS = [
-    'CI',
-    'CONTINUOUS_INTEGRATION',
+    'bamboo.buildKey',
     'BUILD_ID',
     'BUILD_NUMBER',
+    'BUILDKITE',
+    'CI',
+    'CIRCLECI',
+    'CONTINUOUS_INTEGRATION',
+    'GITHUB_ACTIONS',
+    'HUDSON_URL',
+    'JENKINS_URL',
     'TEAMCITY_VERSION',
     'TRAVIS',
-    'CIRCLECI',
-    'JENKINS_URL',
-    'HUDSON_URL',
-    'bamboo.buildKey',
-    'BUILDKITE',
 ]
 
 


### PR DESCRIPTION
As per [their docs](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables), `GITHUB_ACTIONS=true` when GitHub Actions is running.